### PR TITLE
Added path support for third party terminals

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,10 +1,10 @@
-<idea-plugin version="2">
-    <id>com.bobz.OpenTerminalHere</id>
-    <name>Open Terminal Here</name>
-    <version>1.1</version>
-    <vendor email="zhaohevip@gmail.com" url="https://github.com/BobZhao/OpenTerminalHere">SHB</vendor>
+<idea-plugin>
+  <id>com.bobz.OpenTerminalHere</id>
+  <name>Open Terminal Here</name>
+  <version>1.2</version>
+  <vendor email="zhaohevip@gmail.com" url="https://github.com/BobZhao/OpenTerminalHere">SHB</vendor>
 
-    <description><![CDATA[
+  <description><![CDATA[
       An IntelliJ plugin for opening current directory in terminal.<br>
       Source code: https://github.com/BobZhao/OpenTerminalHere
       <br>
@@ -22,42 +22,41 @@
 
     ]]></description>
 
-    <change-notes><![CDATA[
+  <change-notes><![CDATA[
 
     <ul>
-        <li>3/30/2017 v1.1 Add iTerm2 support.</li>
-        <li>4/12/2015 v1.0 Initial version.</li>
+        <li>9/21/2017 v1.1 Add configurable shell paths.</li>
     </ul>
     ]]>
-    </change-notes>
+  </change-notes>
 
-    <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="131"/>
+  <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
+  <idea-version since-build="131"/>
 
-    <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
-         on how to target different products -->
-    <!-- uncomment to enable plugin in all products
-    <depends>com.intellij.modules.lang</depends>
-    -->
+  <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
+       on how to target different products -->
+  <!-- uncomment to enable plugin in all products
+  <depends>com.intellij.modules.lang</depends>
+  -->
 
-    <extensions defaultExtensionNs="com.intellij">
-        <!-- Add your extensions here -->
-    </extensions>
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationConfigurable groupId="tools" displayName="Open Terminal Here" id="OpenTerminalHere.Configuration" instance="com.bobz.configuration.Configuration" />
+  </extensions>
 
-    <application-components>
-        <!-- Add your application components here -->
-    </application-components>
+  <application-components>
+    <!-- Add your application components here -->
+  </application-components>
 
-    <project-components>
-        <!-- Add your project components here -->
-    </project-components>
+  <project-components>
+    <!-- Add your project components here -->
+  </project-components>
 
-    <actions>
-        <action id="com.bobz.action.OpenTerminalHereAction" class="com.bobz.action.OpenTerminalHereAction"
-                text="Open Terminal Here" description="Open Terminal Here">
-            <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="RevealIn"/>
-            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt T"/>
-        </action>
-    </actions>
+  <actions>
+    <action id="com.bobz.action.OpenTerminalHereAction" class="com.bobz.action.OpenTerminalHereAction"
+            text="Open Terminal Here" description="Open Terminal Here">
+      <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="RevealIn"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt T"/>
+    </action>
+  </actions>
 
 </idea-plugin>

--- a/OpenTerminalHere.iml
+++ b/OpenTerminalHere.iml
@@ -8,7 +8,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="IntelliJ IDEA IU-163.12024.16" jdkType="IDEA JDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="org.twodividedbyzero.idea.findbugs">

--- a/src/com/bobz/configuration/Configuration.java
+++ b/src/com/bobz/configuration/Configuration.java
@@ -1,0 +1,103 @@
+package com.bobz.configuration;
+
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.plexus.util.FileUtils;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SearchableConfigurable;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+
+public class Configuration implements SearchableConfigurable, PersistentStateComponent {
+
+  public State state;
+
+  public static String TERM_PATH;
+
+  private static final String TEXT_DISPLAY_NAME = "Open Terminal Here";
+
+  private static final String ID = "OpenTerminalHere.Configuration";
+
+  private JTextField termPath;
+
+  @Nullable
+  @Override
+  public JComponent createComponent() {
+    JPanel panel = initComponent();
+    return panel;
+  }
+
+  @Override
+  public boolean isModified() {
+    return !StringUtils.equals(TERM_PATH, termPath.getText());
+  }
+
+  @Override
+  public void apply() throws ConfigurationException {
+    if (termPath.getText() != null && FileUtils.fileExists(termPath.getText())) {
+      TERM_PATH = termPath.getText();
+    }
+  }
+
+  @Override
+  public void reset() {
+    termPath.setText(TERM_PATH);
+  }
+
+  @Nls
+  @Override
+  public String getDisplayName() {
+    return TEXT_DISPLAY_NAME;
+  }
+
+  @Nullable
+  @Override
+  public String getHelpTopic() {
+    return "Specify the paths for which terminal to use.";
+  }
+
+  private JPanel initComponent() {
+    JLabel pathLabel = new JLabel("Path for which terminal to use:");
+    termPath = new JTextField();
+    termPath.setMaximumSize(new Dimension(Integer.MAX_VALUE, termPath.getPreferredSize().height));
+    termPath.setMinimumSize(new Dimension(20, termPath.getPreferredSize().height));
+
+    JPanel panel = new JPanel();
+    panel.add(pathLabel);
+    panel.add(termPath);
+
+    panel.setLayout(new BoxLayout(panel, BoxLayout.LINE_AXIS));
+
+    return panel;
+  }
+
+  @Nullable
+  @Override
+  public Configuration getState() {
+    return this;
+  }
+
+  @Override
+  public void loadState(Object o) {
+    XmlSerializerUtil.copyBean(state, this);
+  }
+
+  @NotNull
+  @Override
+  public String getId() {
+    return ID;
+  }
+}

--- a/src/com/bobz/executor/MacExecutor.java
+++ b/src/com/bobz/executor/MacExecutor.java
@@ -1,5 +1,9 @@
 package com.bobz.executor;
 
+import org.apache.commons.lang.StringUtils;
+
+import com.bobz.configuration.Configuration;
+
 /**
  * Author: BobZhao
  * Date:   12/2/15 18:42
@@ -17,6 +21,10 @@ public class MacExecutor extends CommandExecutor {
 
     @Override
     public String getTerminalPath() {
+
+        if (!StringUtils.isBlank(Configuration.TERM_PATH)) {
+            return Configuration.TERM_PATH;
+        }
 
         if (isTerminalInstalled(ITERM)) {
             return ITERM;

--- a/src/com/bobz/executor/WinExecutor.java
+++ b/src/com/bobz/executor/WinExecutor.java
@@ -2,6 +2,10 @@ package com.bobz.executor;
 
 import java.io.File;
 
+import org.apache.commons.lang.StringUtils;
+
+import com.bobz.configuration.Configuration;
+
 /**
  * Author: BobZhao
  * Date:   12/2/15 18:43
@@ -11,20 +15,33 @@ public class WinExecutor extends CommandExecutor {
 
     private static final String WIN_CMD = "C:\\Windows\\System32\\cmd.exe";
 
+    private static final String WIN_PSH = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+
     public WinExecutor(String targetPath) {
         super.targetPath = targetPath;
     }
 
     @Override
     public String getTerminalPath() {
-        return WIN_CMD;
+        if (!StringUtils.isBlank(Configuration.TERM_PATH)) {
+            return Configuration.TERM_PATH;
+        } else {
+            return WIN_CMD;
+        }
     }
 
     @Override
     public Command buildCommand() {
+        String[] cmdArr;
 
         String terminalPath = this.getTerminalPath();
-        String[] cmdArr = {terminalPath, "/k", "start", "cd", getTargetPath()};
+        if (terminalPath.equals(WIN_CMD)) {
+            cmdArr = new String[] {terminalPath, "/k", "start", "cd", getTargetPath()};
+        } else if (terminalPath.equals(WIN_PSH)){
+            cmdArr = new String[] { "cmd",  "/c", "start", terminalPath, "-NoExit", "-Command", "cd", getTargetPath() };
+        } else {
+            cmdArr = new String[] {terminalPath};
+        }
 
         return new Command(cmdArr, null, new File(getTargetPath()));
     }


### PR DESCRIPTION
Added support for a configurable path to use third party terminals. I only tested this on Windows and got it to work specifying command prompt, powershell, and conemu. It will fall back to the old functionality if there is no path specified so that it won't break anybody if you merge it. Also, it will not save the paths if the path does not exist.